### PR TITLE
Refactored the AnkiBindingConfig to search subdirectories.

### DIFF
--- a/anki-japanese-flashcard-manager-backend/ApplicationLayer/Config/AnkiBindingConfig.cs
+++ b/anki-japanese-flashcard-manager-backend/ApplicationLayer/Config/AnkiBindingConfig.cs
@@ -9,8 +9,8 @@ namespace anki_japanese_flashcard_manager_backend.ApplicationLayer.Config
 
 		static AnkiBindingConfig()
 		{
-			//Get the bindings JSON data
-			string jsonFilePath = "ankiBindingTags.json";
+			//Get the bindings JSON data (search all subdirectories as it'll move if used as a submodule)
+			string jsonFilePath = Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "ankiBindingTags.json", SearchOption.AllDirectories).FirstOrDefault();
 			string json = File.ReadAllText(jsonFilePath);
 			//Setup the settings to ignore any extra properties
 			JsonSerializerSettings settings = new JsonSerializerSettings


### PR DESCRIPTION
Refactored the AnkiBindingConfig to search subdirectories.
When this repo is used as a submodule, the json file's output directory gets moved into a subdirectory and would previously error out because it couldn't find the file.